### PR TITLE
Add Quickcheck scheduled runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,9 @@ commands:
             EQC_EUNIT_TESTING_TIME_MULTIPLIER: << parameters.multiplier >>
           no_output_timeout: 30m
           command: |
+            # QuickCheck test terget uses git magic to source the dependancy and it needs a user
+            git config --global user.email "ci@aeternity.com"
+            git config --global user.name "Aeternity CI"
             make eqc-lib-test
   fail_notification:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,32 @@ commands:
           key: build-cache-v1-{{ .Revision }}
           paths:
             - "_build"
+      - save_cache:
+          key: quickcheck-cache-v1-{{ .Revision }}
+          paths:
+            - "eqc-lib/eqc.zip"
   restore_build_cache:
     steps:
       - restore_cache:
           keys:
             - build-cache-v1-{{ .Revision }}
+            - quickcheck-cache-v1-{{ .Revision }}
+  quickcheck_tests:
+    parameters:
+      multiplier:
+        type: integer
+    steps:
+      - run:
+          name: QuickCheck Registration
+          command: |
+            make eqc-lib-registration && make eqc-lib-start
+      - run:
+          name: QuickCheck Tests
+          environment:
+            EQC_EUNIT_TESTING_TIME_MULTIPLIER: << parameters.multiplier >>
+          no_output_timeout: 30m
+          command: |
+            make eqc-lib-test
   fail_notification:
     steps:
       - run:
@@ -49,31 +70,38 @@ commands:
           when: on_fail
 
 jobs:
-  build:
+  quickcheck_tests:
+    parameters:
+      multiplier:
+        description: |
+          QuickCheck time multiplier.
+          If max job runtime reached, reduce this testing time multiplier variable (or parallelize job).
+          [Jobs have a maximum runtime of 5 hours.](https://circleci.com/docs/2.0/configuration-reference/#jobs).
+        type: integer
+        default: 40
     executor: builder
     steps:
       - checkout_node
-      - run:
-          name: Build
-          command: make KIND=test
+      - restore_build_cache
+      - quickcheck_tests:
+          multiplier: << parameters.multiplier >>
       - save_build_cache
-      # - fail_notification
-  test:
-    executor: builder
-    steps:
-      - checkout_node
-      - run:
-          name: Test
-          command: |
-            epmd -daemon
-            make eunit
-      # - fail_notification
+      - fail_notification
 
 workflows:
-  build_test:
+  fast_quickcheck:
     jobs:
-      - build:
+      - quickcheck_tests:
           requires: []
-      - test:
-          requires:
-            - build
+          multiplier: 4
+
+  property_based_tests:
+    triggers:
+      - schedule:
+          cron: "0 0,12 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - quickcheck_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,6 @@ jobs:
       multiplier:
         description: |
           QuickCheck time multiplier.
-          If max job runtime reached, reduce this testing time multiplier variable (or parallelize job).
-          [Jobs have a maximum runtime of 5 hours.](https://circleci.com/docs/2.0/configuration-reference/#jobs).
         type: integer
         default: 40
     executor: builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ commands:
           name: QuickCheck Tests
           environment:
             EQC_EUNIT_TESTING_TIME_MULTIPLIER: << parameters.multiplier >>
-          no_output_timeout: 30m
           command: |
             # QuickCheck test terget uses git magic to source the dependancy and it needs a user
             git config --global user.email "ci@aeternity.com"


### PR DESCRIPTION
[PT-165849843][https://www.pivotaltracker.com/story/show/165849843]

Based on [Luca's work ](https://github.com/aeternity/aeternity/pull/2386/files/c93b1f6ee3352553e9a7eda86202b1d8388d9e20..a806056e31ec2daf7270bd642a942dda589a47e6#diff-1d37e48f9ceff6d8030570cd36286a61)

- Successful run with small multiplier: https://circleci.com/gh/aeternity-bot/aeternity-ci/10
- Rerun of the above to prove the cache: https://circleci.com/gh/aeternity-bot/aeternity-ci/11
- See the alerts group for fail notification example/test

I was thinking to remove the `fast_quickcheck` job that runs on each commit/PR, but now I think we should keep it as basic integration test of the configuration of this repo ?